### PR TITLE
Handle array destructuring assignment with ignored values

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,7 +360,7 @@ function visit(ast, context, visitor) {
       stack = stack.prev;
     } else {
       var node = parent ? parent[keys[index]] : ast.program;
-      if (node && typeof node === 'object' && (node.type || node.length && node[0].type)) {
+      if (node && typeof node === 'object' && (node.type || node.length)) {
         if (node.type) {
           var visitFn = visitor[node.type];
           if (visitFn && visitFn(context, node, ast) === false) {


### PR DESCRIPTION
Avoid `TypeError: Cannot read property 'type' of null` triggered by parse of array destructuring assignment with ignored values, e.g. `const [, y] = pair;`