### PR TITLE
Fix help options ensuring the --all argument is printed

### DIFF
--- a/flow-node
+++ b/flow-node
@@ -16,7 +16,7 @@ var usage = 'Usage: flow-node [options] [ script.js ] [arguments] \n' +
 '  -v, --version         Prints the current version of flow-node\n' +
 '  -e, --eval script     Evaluate script\n' +
 '  -p, --print script    Evaluate script and print result\n' +
-'  -c, --check           Syntax check script without executing\n';
+'  -c, --check           Syntax check script without executing\n' +
 '  -a, --all             Interpret all files as flow-typed, not just those with a @flow comment\n';
 
 // Collect arguments


### PR DESCRIPTION
I small fix where a `;` resulted in the last line of the help text didn't get printed.

#### Before
```bash
$ flow-node -h
Usage: flow-node [options] [ script.js ] [arguments]

Options:
  -h, --help            Show this message
  -v, --version         Prints the current version of flow-node
  -e, --eval script     Evaluate script
  -p, --print script    Evaluate script and print result
  -c, --check           Syntax check script without executing
```

#### After

```bash
$ flow-node -h
Usage: flow-node [options] [ script.js ] [arguments]

Options:
  -h, --help            Show this message
  -v, --version         Prints the current version of flow-node
  -e, --eval script     Evaluate script
  -p, --print script    Evaluate script and print result
  -c, --check           Syntax check script without executing
  -a, --all             Interpret all files as flow-typed, not just those with a @flow comment
```