### PR TITLE
Bugfix allowing --all option to be passed when executing script

### DIFF
--- a/flow-node
+++ b/flow-node
@@ -84,6 +84,10 @@ if (options.length > 0) {
 
 require('./register')({ all: all });
 
+function withoutOptions(optionsToExclude, options) {
+  return options.filter((option) => !optionsToExclude.includes(option))
+}
+
 // Evaluate and possibly also print a script.
 if (evalScript || printScript) {
   global.__filename = '[eval]';
@@ -120,8 +124,9 @@ if (evalScript || printScript) {
 // Or run the script.
 } else if (source) {
   var absoluteSource = path.resolve(process.cwd(), source);
+  var previousOptions = process.argv.slice(2, i - 1)
   process.argv = [ 'node' ].concat(
-    process.argv.slice(2, i - 1),
+    withoutOptions(['-a', '--all'], previousOptions),
     absoluteSource,
     process.argv.slice(i)
   );


### PR DESCRIPTION
Previously passing `--all` or `-a` would break when executing a script:

```bash
$ /node_modules/.bin/flow-node --all ./src/server.js
module.js:327
    throw err;
    ^

Error: Cannot find module '--all'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)

    ...
```

Excluding those options before executing the scripts fixes the issue.