### PR TITLE
Support esm module extension - .mjs

### DIFF
--- a/flow-remove-types
+++ b/flow-remove-types
@@ -68,7 +68,7 @@ function mkdirp(dirpath) {
 
 // Collect arguments
 var ignore = /node_modules/;
-var extensions = [ '.js', '.jsx', '.flow', '.es6' ];
+var extensions = [ '.js', '.mjs', '.jsx', '.flow', '.es6' ];
 var outDir;
 var outFile;
 var all;

--- a/register.js
+++ b/register.js
@@ -19,7 +19,7 @@ module.exports = function setOptions(newOptions) {
 // this require hook must come after it. Encourage those module authors to call
 // the prior loader in their require hooks.
 var jsLoader = require.extensions['.js'];
-var exts = [ '.js', '.jsx', '.flow', '.es6' ];
+var exts = [ '.js', '.mjs', '.jsx', '.flow', '.es6' ];
 exts.forEach(function (ext) {
   var superLoader = require.extensions[ext] || jsLoader;
   require.extensions[ext] = function (module, filename) {


### PR DESCRIPTION
This PR adds `.mjs` to the list of file extensions supported in the require hook `register.js` module.