### PR TITLE
Do not remove @flow if outside comment.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -29,6 +29,11 @@ echo "Test: flow-remove-types --pretty --sourcemaps inline test/source.js"
 DIFF=$(./flow-remove-types --pretty --sourcemaps inline test/source.js | diff test/expected-pretty-inlinemap.js -);
 if [ -n "$DIFF" ]; then echo "$DIFF"; exit 1; fi;
 
+# Test expected output with @flow outside of comments
+echo "Test: flow-remove-types test/without-flow.js"
+DIFF=$(./flow-remove-types test/without-flow.js | diff test/without-flow.js -);
+if [ -n "$DIFF" ]; then echo "$DIFF"; exit 1; fi;
+
 # Test node require hook
 echo "Test: node require hook"
 RES=$(node -e 'require("./register");require("./test/test-node-module.js")');

--- a/test/without-flow.js
+++ b/test/without-flow.js
@@ -1,0 +1,3 @@
+function hasNoFlow(flow) {
+  return '@flow'.test(/@flow/)
+}


### PR DESCRIPTION
Checks to see if the pragma is contained within a comment before attempting to remove it. Also, replace the slice('\n') conversion to line/col with a more efficient option.

Fixes #50 