### PR TITLE
explicitly use bash

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Test expected output
 echo "Test: flow-remove-types test/source.js"


### PR DESCRIPTION
In debian /bin/sh is symlink to dash. Since the script has bash specific options, it will fail when run as ./test.sh

./test.sh: 15: ./test.sh: Bad substitution
./test.sh: 18: ./test.sh: pushd: not found