### PR TITLE
Register hook: errors include filenames

### DIFF
--- a/register.js
+++ b/register.js
@@ -26,7 +26,14 @@ exts.forEach(function (ext) {
     if (shouldTransform(filename, options)) {
       var super_compile = module._compile;
       module._compile = function _compile(code, filename) {
-        super_compile.call(this, flowRemoveTypes(code, options).toString(), filename);
+        try {
+          var patched = flowRemoveTypes(code, options);
+        }
+        catch (e) {
+          e.message = filename + ': ' + e.message;
+          throw e;
+        }
+        super_compile.call(this, patched.toString(), filename);
       };
     }
     superLoader(module, filename);


### PR DESCRIPTION
Makes syntax errors print out like:
> SyntaxError: /path/to/code/somefile_with_typo.js: Unexpected token (4:0)
> .... useless bablyon stack trace

instead of like:

> SyntaxError: Unexpected token (4:0)
> .... useless bablyon stack trace



This makes it obvious which file the parse failed on which is extremely useful if developing across many files.