### PR TITLE
Upgrade babylon to v7

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports = function flowRemoveTypes(source, options) {
     allowReturnOutsideFunction: true,
     allowSuperOutsideMethod: true,
     sourceType: 'module',
-    plugins: [ '*', 'jsx', 'flow' ],
+    plugins: [ '*', 'jsx', 'flow', 'classProperties' ],
+    tokens: true
   });
 
   var removedNodes = [];

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "es6"
   ],
   "dependencies": {
-    "babylon": "^6.15.0",
+    "babylon": "^7.0.0-beta.41",
     "vlq": "^0.2.1"
   }
 }


### PR DESCRIPTION
Babylon v7 is WAY faster than the currently used version, and parsing to AST takes almost the whole time of `remove-flow-types`, so this upgrade would make all bundles that use this package much faster (e.g. it shaves off 400-500ms off the [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js) bundle). 

Babel v7 is [nearing release](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) and babylon@next is very stable (and fixes a huge bunch of issues), so I think it's safe to upgrade despite the beta status. No problem if you want to wait for the final release though.