### PR TITLE
Add --copy-source option (.flow)

### DIFF
--- a/flow-remove-types
+++ b/flow-remove-types
@@ -14,6 +14,8 @@ var usage = 'Usage: flow-remove-types [options] [sources] \n' +
 '  -x, --extensions  File extensions to transform\n' +
 '  -o, --out-file    The file path to write transformed file to\n' +
 '  -d, --out-dir     The directory path to write transformed files within\n' +
+'  -c, --copy-source Copy typed source with .flow extension to output\n' +
+'                    Only applies when --out-file or --out-dir options are used\n' +
 '  -a, --all         Transform all files, not just those with a @flow comment\n' +
 '  -p, --pretty      Remove flow types without replacing with spaces, \n' +
 '                    producing prettier output but may require using source maps\n' +
@@ -71,6 +73,7 @@ var ignore = /node_modules/;
 var extensions = [ '.js', '.mjs', '.jsx', '.flow', '.es6' ];
 var outDir;
 var outFile;
+var copySource;
 var all;
 var pretty;
 var sourceMaps;
@@ -94,6 +97,8 @@ while (i < process.argv.length) {
     outFile = process.argv[i++];
   } else if (arg === '-d' || arg === '--out-dir') {
     outDir = process.argv[i++];
+  } else if (arg === '-c' || arg === '--copy-source') {
+    copySource = true;
   } else if (arg === '-a' || arg === '--all') {
     all = true;
   } else if (arg === '-p' || arg === '--pretty') {
@@ -219,6 +224,11 @@ function transformAndOutput(content, outFile, source) {
       var mapOutFile = outFile + '.map';
       fs.writeFileSync(mapOutFile, JSON.stringify(map) + '\n');
       info('\033[2m \u21B3 \033[32m' + mapOutFile + '\033[0m\n');
+    }
+    if (copySource) {
+      var flowSource = outFile + '.flow';
+      fs.writeFileSync(flowSource, content);
+      info('\033[2m \u21B3 \033[32m' + flowSource + '\033[0m\n');
     }
   } else {
     process.stdout.write(code);

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ echo "Test: flow-remove-types --pretty test/source.js"
 DIFF=$(./flow-remove-types --pretty test/source.js | diff test/expected-pretty.js -);
 if [ -n "$DIFF" ]; then echo "$DIFF"; exit 1; fi;
 
-# Test expected source maps with --pretty --sourcemaps
+# Test expected source maps with --pretty --sourcemaps --out-dir
 echo "Test: flow-remove-types --pretty --sourcemaps test/source.js -d test/expected-with-maps"
 TEST_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 DIR=$(mktemp -d)
@@ -23,6 +23,23 @@ DIFF_MAP=$(diff test/expected-with-maps/test/source.js.map $DIR/test/expected-wi
 rm -rf $DIR
 if [ -n "$DIFF_SOURCE" ]; then echo "$DIFF_SOURCE"; exit 1; fi;
 if [ -n "$DIFF_MAP" ]; then echo "$DIFF_MAP"; exit 1; fi;
+
+# Test expected source maps with --copy-source --pretty --sourcemaps --out-dir
+echo "Test: flow-remove-types --copy-source --pretty --sourcemaps test/source.js -d test/expected-with-maps"
+TEST_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
+DIR=$(mktemp -d)
+cp -r test $DIR
+pushd $DIR > /dev/null
+$TEST_DIR/flow-remove-types --copy-source --pretty --sourcemaps test/source.js -d test/expected-with-maps;
+popd > /dev/null
+DIFF_SOURCE=$(diff test/expected-with-maps/test/source.js $DIR/test/expected-with-maps/test/source.js);
+DIFF_MAP=$(diff test/expected-with-maps/test/source.js.map $DIR/test/expected-with-maps/test/source.js.map);
+DIFF_FLOW=$(diff test/source.js $DIR/test/expected-with-maps/test/source.js.flow);
+echo $DIR
+rm -rf $DIR
+if [ -n "$DIFF_SOURCE" ]; then echo "$DIFF_SOURCE"; exit 1; fi;
+if [ -n "$DIFF_MAP" ]; then echo "$DIFF_MAP"; exit 1; fi;
+if [ -n "$DIFF_FLOW" ]; then echo "$DIFF_FLOW"; exit 1; fi;
 
 # Test expected source maps with --pretty --sourcemaps inline
 echo "Test: flow-remove-types --pretty --sourcemaps inline test/source.js"

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,6 @@ popd > /dev/null
 DIFF_SOURCE=$(diff test/expected-with-maps/test/source.js $DIR/test/expected-with-maps/test/source.js);
 DIFF_MAP=$(diff test/expected-with-maps/test/source.js.map $DIR/test/expected-with-maps/test/source.js.map);
 DIFF_FLOW=$(diff test/source.js $DIR/test/expected-with-maps/test/source.js.flow);
-echo $DIR
 rm -rf $DIR
 if [ -n "$DIFF_SOURCE" ]; then echo "$DIFF_SOURCE"; exit 1; fi;
 if [ -n "$DIFF_MAP" ]; then echo "$DIFF_MAP"; exit 1; fi;


### PR DESCRIPTION
This PR adds a `-c, --copy-source` options to **Copy typed source with .flow extension to output** which **Only applies when --out-file or --out-dir options are used**.

Using this option will copy `src/file.ext` to `dest/file.ext.flow` (where `ext` is any extension supported by `flow-remove-types`) anytime there is an output file.